### PR TITLE
Added testing instructions to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ http.listen(3000);
 
   Attaches the mydb server to a `http.Server`.
 
+## Testing
+In order to run the tests
+* Start Redis: `redis-server`
+* Start MongoDB: `mongod`
+* Run the tests: `make test`
+
 ## License
 
 MIT


### PR DESCRIPTION
If you run the tests without first starting redis, this error appears:

```
  ․․․․․

  4 passing (17ms)
  1 failing

  1) mydb attaching should work without `new`:
     Uncaught Error: Redis connection to localhost:6379 failed - connect ECONNREFUSED
      at RedisClient.on_error (/Users/greg/Code/open-source/mydb/node_modules/redis/index.js:151:24)
      at Socket.<anonymous> (/Users/greg/Code/open-source/mydb/node_modules/redis/index.js:86:14)
      at Socket.EventEmitter.emit (events.js:95:17)
      at net.js:441:14
      at process._tickCallback (node.js:415:13)
```

If you the tests with redis running, but not mongo, this error appears:

```
  ․․․․Error: failed to connect to [localhost:27017]
    at null.<anonymous> (/Users/greg/Code/open-source/mydb/node_modules/mydb-driver/node_modules/monk/node_modules/mongoskin/node_modules/mongodb/lib/mongodb/connection/server.js:482:73)
    at EventEmitter.emit (events.js:95:17)
    at null.<anonymous> (/Users/greg/Code/open-source/mydb/node_modules/mydb-driver/node_modules/monk/node_modules/mongoskin/node_modules/mongodb/lib/mongodb/connection/connection_pool.js:96:15)
    at EventEmitter.emit (events.js:98:17)
    at Socket.<anonymous> (/Users/greg/Code/open-source/mydb/node_modules/mydb-driver/node_modules/monk/node_modules/mongoskin/node_modules/mongodb/lib/mongodb/connection/connection.js:411:10)
    at Socket.EventEmitter.emit (events.js:95:17)
    at net.js:441:14
    at process._tickCallback (node.js:415:13)
․

  4 passing (108ms)
  1 failing

  1) mydb exposing should expose docs:
     Uncaught Error: expected undefined to equal 'Test'
      at Assertion.assert (/Users/greg/Code/open-source/mydb/node_modules/expect.js/expect.js:99:13)
      at Assertion.be.Assertion.equal (/Users/greg/Code/open-source/mydb/node_modules/expect.js/expect.js:200:10)
      at Assertion.(anonymous function) [as be] (/Users/greg/Code/open-source/mydb/node_modules/expect.js/expect.js:73:24)
      at /Users/greg/Code/open-source/mydb/test/mydb.js:96:32
      at /Users/greg/Code/open-source/mydb/node_modules/mydb-client/document.js:373:13
      at Request.callback (/Users/greg/Code/open-source/mydb/node_modules/mydb-client/node_modules/superagent/lib/node/index.js:628:30)
      at Request.<anonymous> (/Users/greg/Code/open-source/mydb/node_modules/mydb-client/node_modules/superagent/lib/node/index.js:131:10)
      at Request.EventEmitter.emit (events.js:95:17)
      at IncomingMessage.<anonymous> (/Users/greg/Code/open-source/mydb/node_modules/mydb-client/node_modules/superagent/lib/node/index.js:773:12)
      at IncomingMessage.EventEmitter.emit (events.js:117:20)
      at _stream_readable.js:920:16
      at process._tickCallback (node.js:415:13)
```
